### PR TITLE
Add support for byte-like opened files

### DIFF
--- a/ofxtools/Parser.py
+++ b/ofxtools/Parser.py
@@ -93,6 +93,8 @@ class OFXTree(ET.ElementTree):
             source = open(source)
         with source as s:
             source = s.read()
+            if hasattr(source, 'decode'):
+                source = source.decode()
 
         # Validate and strip the OFX header
         source = OFXHeader.strip(source)


### PR DESCRIPTION
I came across a bug in ofxtools when a OFX file is uploaded via apache because the python cgi module open the uploaded file in Bytes mode. When passing the file object to the parser, bytes are read instead of a string. This PR fixes this by decoding the bytes if the decode() function is available.