### PR TITLE
Fix multiple proprietary tags

### DIFF
--- a/ofxtools/models/common.py
+++ b/ofxtools/models/common.py
@@ -65,7 +65,7 @@ class MSGSETCORE(Aggregate):
         """
         Remove proprietary tags e.g. INTU.XXX
         """
-        for child in elem:
+        for child in set(elem):
             if '.' in child.tag:
                 elem.remove(child)
 

--- a/ofxtools/models/profile.py
+++ b/ofxtools/models/profile.py
@@ -51,7 +51,7 @@ class PROFRS(Aggregate):
         """
         Remove proprietary tags e.g. INTU.XXX
         """
-        for child in elem:
+        for child in set(elem):
             if '.' in child.tag:
                 elem.remove(child)
 

--- a/ofxtools/models/signon.py
+++ b/ofxtools/models/signon.py
@@ -57,6 +57,18 @@ class SONRS(Aggregate):
     accesskey = String(1000)
     ofxextension = Unsupported()
 
+    @staticmethod
+    def groom(elem):
+        
+        """
+        Remove proprietary tags e.g. INTU.XXX
+        """
+        for child in set(elem):
+            if '.' in child.tag:
+                elem.remove(child)
+
+        return super(SONRS, SONRS).groom(elem)
+
     # Human-friendly attribute aliases
     @property
     def org(self):


### PR DESCRIPTION
Only the first proprietary tag would remove from elementree because remove method reset the elementtree iterator.  This returns the iterator as a set list object instead.

This also removes proprietary tags from SONRS as well - support Merrill Edge qfx file downloads.