### PR TITLE
Don't quantize if no precision was specified

### DIFF
--- a/ofxtools/Client.py
+++ b/ofxtools/Client.py
@@ -216,6 +216,9 @@ class OFXClient(object):
         if dryrun:
             return BytesIO(data.encode("ascii"))
 
+        # Deal with buggy Vanguard OFX gateway
+        data = data.replace("</SONRQ>", "\n</SONRQ>")
+
         mimetype = 'application/x-ofx'
         headers = {'Content-type': mimetype, 'Accept': '*/*, %s' % mimetype}
 

--- a/ofxtools/Types.py
+++ b/ofxtools/Types.py
@@ -222,11 +222,12 @@ class Integer(Element):
 
 class Decimal(Element):
     def _init(self, *args, **kwargs):
-        precision = 2
         if args:
             precision = args[0]
             args = args[1:]
-        self.precision = decimal.Decimal('0.' + '0'*(precision-1) + '1')
+            self.precision = decimal.Decimal('0.' + '0'*(precision-1) + '1')
+        else:
+            self.precision = None
         super(Decimal, self)._init(*args, **kwargs)
 
     def convert(self, value):
@@ -243,7 +244,9 @@ class Decimal(Element):
             if isinstance(value, basestring):
                 value = decimal.Decimal(value.replace(',', '.'))
 
-        return value.quantize(self.precision)
+        if self.precision is not None:
+            value = value.quantize(self.precision)
+        return value
 
 
 class DateTime(Element):


### PR DESCRIPTION
I recently discovered that my financial institution was actually providing 3 decimal places of precision for my assets under management, unfortunately ofxtools removes this information.

Change the default so that Decimal values aren't quantized if no quantization is requested in the type definition. This provides the application with the same precision contained within the ofx response.

The only types that specify a precision are contained with ofxtools/models/seclist.py, and I wonder if those should be removed as well.