### PR TITLE
Support datetimes with timezones.  Return datetimes with timezones.

### DIFF
--- a/ofxtools/utils.py
+++ b/ofxtools/utils.py
@@ -241,3 +241,30 @@ def findEaster(year):
     d = 1+(p+27+(p+6)/40)%31
     m = 3+(p+26)/30
     return datetime.date(y,m,d)
+
+
+try:
+    # If pytz is installed then use that.
+    import pytz
+    UTC = pytz.UTC
+except ImportError:
+    # Otherwise create our own UTC tzinfo.
+    class _UTC(datetime.tzinfo):
+
+        def tzname(self, dt):
+            """datetime -> string name of time zone."""
+            return "UTC"
+
+        def utcoffset(self, dt):
+            """datetime -> minutes east of UTC (negative for west of UTC)"""
+            return datetime.timedelta(0)
+
+        def dst(self, dt):
+            """datetime -> DST offset in minutes east of UTC.
+
+            Return 0 if DST not in effect.  utcoffset() must include the DST
+            offset.
+            """
+            return datetime.timedelta(0)
+
+    UTC = _UTC()

--- a/tests/test_bank.py
+++ b/tests/test_bank.py
@@ -2,6 +2,7 @@
 
 # stdlib imports
 import unittest
+import datetime
 from xml.etree.ElementTree import (
     Element,
     SubElement,
@@ -11,6 +12,7 @@ from decimal import Decimal
 
 
 # local imports
+from ofxtools.utils import UTC
 from . import base
 import ofxtools.models
 from ofxtools.models.base import Aggregate
@@ -191,9 +193,9 @@ class StmttrnTestCase(unittest.TestCase, base.TestAggregate):
         root = Aggregate.from_etree(self.root)
         self.assertIsInstance(root, STMTTRN)
         self.assertEqual(root.trntype, 'CHECK')
-        self.assertEqual(root.dtposted, datetime(2013, 6, 15))
-        self.assertEqual(root.dtuser, datetime(2013, 6, 14))
-        self.assertEqual(root.dtavail, datetime(2013, 6, 16))
+        self.assertEqual(root.dtposted, datetime(2013, 6, 15, tzinfo=UTC))
+        self.assertEqual(root.dtuser, datetime(2013, 6, 14, tzinfo=UTC))
+        self.assertEqual(root.dtavail, datetime(2013, 6, 16, tzinfo=UTC))
         self.assertEqual(root.trnamt, Decimal('-433.25'))
         self.assertEqual(root.fitid, 'DEADBEEF')
         self.assertEqual(root.correctfitid, 'B00B5')
@@ -428,8 +430,8 @@ class BanktranlistTestCase(unittest.TestCase, base.TestAggregate):
         # Test *TRANLIST wrapper.  STMTTRN is tested elsewhere.
         root = Aggregate.from_etree(self.root)
         self.assertIsInstance(root, BANKTRANLIST)
-        self.assertEqual(root.dtstart, datetime(2013, 6, 1))
-        self.assertEqual(root.dtend, datetime(2013, 6, 30))
+        self.assertEqual(root.dtstart, datetime(2013, 6, 1, tzinfo=UTC))
+        self.assertEqual(root.dtend, datetime(2013, 6, 30, tzinfo=UTC))
         self.assertEqual(len(root), 2)
         for i in range(2):
             self.assertIsInstance(root[i], STMTTRN)
@@ -452,7 +454,7 @@ class LedgerbalTestCase(unittest.TestCase, base.TestAggregate):
         root = Aggregate.from_etree(self.root)
         self.assertIsInstance(root, LEDGERBAL)
         self.assertEqual(root.balamt, Decimal('12345.67'))
-        self.assertEqual(root.dtasof, datetime(2005, 10, 29, 10, 10, 3))
+        self.assertEqual(root.dtasof, datetime(2005, 10, 29, 10, 10, 3, tzinfo=UTC))
 
 
 class AvailbalTestCase(unittest.TestCase, base.TestAggregate):
@@ -472,7 +474,7 @@ class AvailbalTestCase(unittest.TestCase, base.TestAggregate):
         root = Aggregate.from_etree(self.root)
         self.assertIsInstance(root, AVAILBAL)
         self.assertEqual(root.balamt, Decimal('12345.67'))
-        self.assertEqual(root.dtasof, datetime(2005, 10, 29, 10, 10, 3))
+        self.assertEqual(root.dtasof, datetime(2005, 10, 29, 10, 10, 3, tzinfo=UTC))
 
 
 class StmtrsTestCase(unittest.TestCase, base.TestAggregate):

--- a/tests/test_investment.py
+++ b/tests/test_investment.py
@@ -38,6 +38,7 @@ from ofxtools.models.investment import (
 from ofxtools.models.i18n import (
     CURRENCY, CURRENCY_CODES,
 )
+from ofxtools.utils import UTC
 from . import base
 from . import test_models_common
 from . import test_bank
@@ -185,8 +186,8 @@ class InvtranlistTestCase(unittest.TestCase, base.TestAggregate):
         # Test *TRANLIST wrapper.  STMTTRN is tested elsewhere.
         root = Aggregate.from_etree(self.root)
         self.assertIsInstance(root, INVTRANLIST)
-        self.assertEqual(root.dtstart, datetime(2013, 6, 1))
-        self.assertEqual(root.dtend, datetime(2013, 6, 30))
+        self.assertEqual(root.dtstart, datetime(2013, 6, 1, tzinfo=UTC))
+        self.assertEqual(root.dtend, datetime(2013, 6, 30, tzinfo=UTC))
         self.assertEqual(len(root), 21)
         for i, it in enumerate((INVBANKTRAN, BUYDEBT, BUYMF, BUYOPT, BUYOTHER,
                                 BUYSTOCK, CLOSUREOPT, INCOME, INVEXPENSE,
@@ -253,8 +254,8 @@ class InvtranTestCase(unittest.TestCase, base.TestAggregate):
         root = Aggregate.from_etree(self.root)
         self.assertEqual(root.fitid, '1001')
         self.assertEqual(root.srvrtid, '2002')
-        self.assertEqual(root.dttrade, datetime(2004, 7, 1))
-        self.assertEqual(root.dtsettle, datetime(2004, 7, 4))
+        self.assertEqual(root.dttrade, datetime(2004, 7, 1, tzinfo=UTC))
+        self.assertEqual(root.dtsettle, datetime(2004, 7, 4, tzinfo=UTC))
         self.assertEqual(root.reversalfitid, '3003')
         self.assertEqual(root.memo, 'Investment Transaction')
         return root
@@ -315,7 +316,7 @@ class InvbuyTestCase(unittest.TestCase, base.TestAggregate):
         self.assertEqual(root.loanprincipal, Decimal('1.50'))
         self.assertEqual(root.loaninterest, Decimal('3.50'))
         self.assertEqual(root.inv401ksource, 'PROFITSHARING')
-        self.assertEqual(root.dtpayroll, datetime(2004, 6, 15))
+        self.assertEqual(root.dtpayroll, datetime(2004, 6, 15, tzinfo=UTC))
         self.assertEqual(root.prioryearcontrib, True)
         return root
 
@@ -1282,7 +1283,7 @@ class TransferTestCase(unittest.TestCase, base.TestAggregate):
         self.assertIsInstance(root.invacctfrom, INVACCTFROM)
         self.assertEqual(root.avgcostbasis, Decimal('22.22'))
         self.assertEqual(root.unitprice, Decimal('23.01'))
-        self.assertEqual(root.dtpurchase, datetime(1999, 12, 31))
+        self.assertEqual(root.dtpurchase, datetime(1999, 12, 31, tzinfo=UTC))
         self.assertEqual(root.inv401ksource, 'PROFITSHARING')
         return root
 
@@ -1654,7 +1655,7 @@ class OobuydebtTestCase(unittest.TestCase, base.TestAggregate):
         root = Aggregate.from_etree(self.root)
         self.assertIsInstance(root.oo, OO)
         self.assertEqual(root.auction, False)
-        self.assertEqual(root.dtauction, datetime(2012, 1, 9))
+        self.assertEqual(root.dtauction, datetime(2012, 1, 9, tzinfo=UTC))
 
 
 class OobuymfTestCase(unittest.TestCase, base.TestAggregate):
@@ -1930,7 +1931,7 @@ class InvstmtrsTestCase(unittest.TestCase, base.TestAggregate):
         # Everything below that is tested elsewhere.
         root = Aggregate.from_etree(self.root)
         self.assertIsInstance(root, INVSTMTRS)
-        self.assertEqual(root.dtasof, datetime(2001, 5, 30))
+        self.assertEqual(root.dtasof, datetime(2001, 5, 30, tzinfo=UTC))
         self.assertEqual(root.curdef, 'USD')
         self.assertIsInstance(root.invacctfrom, INVACCTFROM)
         self.assertIsInstance(root.invtranlist, INVTRANLIST)

--- a/tests/test_models_common.py
+++ b/tests/test_models_common.py
@@ -18,6 +18,7 @@ from ofxtools.models.common import (
     STATUS, BAL, CURRENCY, OFXELEMENT, OFXEXTENSION, MSGSETCORE,
 )
 from ofxtools.models.i18n import (CURRENCY_CODES, LANG_CODES)
+from ofxtools.utils import UTC
 
 
 class StatusTestCase(unittest.TestCase, base.TestAggregate):
@@ -74,7 +75,7 @@ class BalTestCase(unittest.TestCase, base.TestAggregate):
         self.assertEqual(root.desc, 'Balance')
         self.assertEqual(root.baltype, 'DOLLAR')
         self.assertEqual(root.value, Decimal('111.22'))
-        self.assertEqual(root.dtasof, datetime(2001, 6, 30))
+        self.assertEqual(root.dtasof, datetime(2001, 6, 30, tzinfo=UTC))
         self.assertIsInstance(root.currency, CURRENCY)
 
     def testOneOf(self):

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -18,6 +18,7 @@ from ofxtools.models.profile import (
     PROFRQ, PROFRS, PROFTRNRQ, PROFTRNRS, MSGSETLIST, PROFMSGSETV1, PROFMSGSET,
 )
 from ofxtools.models.signon import (SIGNONINFOLIST, )
+from ofxtools.utils import UTC
 
 from . import base
 from . import test_models_common
@@ -45,7 +46,7 @@ class ProfrqTestCase(unittest.TestCase, base.TestAggregate):
         root = Aggregate.from_etree(self.root)
         self.assertIsInstance(root, PROFRQ)
         self.assertEqual(root.clientrouting, 'SERVICE')
-        self.assertEqual(root.dtprofup, datetime(2001, 4, 1))
+        self.assertEqual(root.dtprofup, datetime(2001, 4, 1, tzinfo=UTC))
 
     def testOneOf(self):
         self.oneOfTest('CLIENTROUTING', ('NONE', 'SERVICE', 'MSGSET'))
@@ -129,7 +130,7 @@ class ProfrsTestCase(unittest.TestCase, base.TestAggregate):
         self.assertIsInstance(root, PROFRS)
         self.assertIsInstance(root.msgsetlist, MSGSETLIST)
         self.assertIsInstance(root.signoninfolist, SIGNONINFOLIST)
-        self.assertEqual(root.dtprofup, datetime(2001, 4, 1))
+        self.assertEqual(root.dtprofup, datetime(2001, 4, 1, tzinfo=UTC))
         self.assertEqual(root.finame, 'Dewey Cheatham & Howe')
         self.assertEqual(root.addr1, '3717 N Clark St')
         self.assertEqual(root.addr2, 'Dugout Box, Aisle 19')

--- a/tests/test_seclist.py
+++ b/tests/test_seclist.py
@@ -11,6 +11,7 @@ from xml.etree.ElementTree import (
 
 
 # local imports
+from ofxtools.utils import UTC
 from . import base
 from . import test_seclist
 from . import test_i18n
@@ -110,14 +111,14 @@ class DebtinfoTestCase(unittest.TestCase, base.TestAggregate):
         self.assertEqual(root.debttype, 'COUPON')
         self.assertEqual(root.debtclass, 'CORPORATE')
         self.assertEqual(root.couponrt, Decimal('5.125'))
-        self.assertEqual(root.dtcoupon, datetime(2003, 12, 1))
+        self.assertEqual(root.dtcoupon, datetime(2003, 12, 1, tzinfo=UTC))
         self.assertEqual(root.couponfreq, 'QUARTERLY')
         self.assertEqual(root.callprice, Decimal('1000'))
         self.assertEqual(root.yieldtocall, Decimal('6.5'))
-        self.assertEqual(root.dtcall, datetime(2005, 12, 15))
+        self.assertEqual(root.dtcall, datetime(2005, 12, 15, tzinfo=UTC))
         self.assertEqual(root.calltype, 'CALL')
         self.assertEqual(root.yieldtomat, Decimal('6.0'))
-        self.assertEqual(root.dtmat, datetime(2006, 12, 15))
+        self.assertEqual(root.dtmat, datetime(2006, 12, 15, tzinfo=UTC))
         self.assertEqual(root.assetclass, 'INTLBOND')
         self.assertEqual(root.fiassetclass, 'Fixed to floating bond')
 
@@ -243,7 +244,7 @@ class MfinfoTestCase(unittest.TestCase, base.TestAggregate):
         self.assertIsInstance(root.secinfo, SECINFO)
         self.assertEqual(root.mftype, 'OPENEND')
         self.assertEqual(root.yld, Decimal('5.0'))
-        self.assertEqual(root.dtyieldasof, datetime(2003, 5, 1))
+        self.assertEqual(root.dtyieldasof, datetime(2003, 5, 1, tzinfo=UTC))
         self.assertIsInstance(root.mfassetclass, MFASSETCLASS)
         self.assertIsInstance(root.fimfassetclass, FIMFASSETCLASS)
 
@@ -283,7 +284,7 @@ class OptinfoTestCase(unittest.TestCase, base.TestAggregate):
         self.assertIsInstance(root.secinfo, SECINFO)
         self.assertEqual(root.opttype, 'CALL')
         self.assertEqual(root.strikeprice, Decimal('25.5'))
-        self.assertEqual(root.dtexpire, datetime(2003, 12, 15))
+        self.assertEqual(root.dtexpire, datetime(2003, 12, 15, tzinfo=UTC))
         self.assertEqual(root.shperctrct, 100)
         self.assertEqual(root.assetclass, 'SMALLSTOCK')
         self.assertEqual(root.fiassetclass, 'FOO')
@@ -350,7 +351,7 @@ class StockinfoTestCase(unittest.TestCase, base.TestAggregate):
         self.assertIsInstance(root.secinfo, SECINFO)
         self.assertEqual(root.stocktype, 'CONVERTIBLE')
         self.assertEqual(root.yld, Decimal('5.0'))
-        self.assertEqual(root.dtyieldasof, datetime(2003, 5, 1))
+        self.assertEqual(root.dtyieldasof, datetime(2003, 5, 1, tzinfo=UTC))
         self.assertEqual(root.assetclass, 'SMALLSTOCK')
         self.assertEqual(root.fiassetclass, 'FOO')
 

--- a/tests/test_signon.py
+++ b/tests/test_signon.py
@@ -17,6 +17,7 @@ from ofxtools.models.signon import (
     SIGNONINFO, SIGNONINFOLIST,
 )
 from ofxtools.models.i18n import LANG_CODES
+from ofxtools.utils import UTC
 
 from . import base
 from . import test_models_common
@@ -72,7 +73,7 @@ class SonrqTestCase(unittest.TestCase, base.TestAggregate):
         # Aggregate instance attributes with the result
         root = Aggregate.from_etree(self.root)
         self.assertIsInstance(root, SONRQ)
-        self.assertEqual(root.dtclient, datetime(2005, 10, 29, 10, 10, 3))
+        self.assertEqual(root.dtclient, datetime(2005, 10, 29, 10, 10, 3, tzinfo=UTC))
         self.assertEqual(root.userkey, 'DEADBEEF')
         self.assertEqual(root.genuserkey, False)
         self.assertEqual(root.language, 'ENG')
@@ -119,12 +120,12 @@ class SonrsTestCase(unittest.TestCase, base.TestAggregate):
         root = Aggregate.from_etree(self.root)
         self.assertIsInstance(root, SONRS)
         self.assertIsInstance(root.status, STATUS)
-        self.assertEqual(root.dtserver, datetime(2005, 10, 29, 10, 10, 3))
+        self.assertEqual(root.dtserver, datetime(2005, 10, 29, 10, 10, 3, tzinfo=UTC))
         self.assertEqual(root.userkey, 'DEADBEEF')
-        self.assertEqual(root.tskeyexpire, datetime(2005, 12, 31))
+        self.assertEqual(root.tskeyexpire, datetime(2005, 12, 31, tzinfo=UTC))
         self.assertEqual(root.language, 'ENG')
-        self.assertEqual(root.dtprofup, datetime(2005, 1, 1))
-        self.assertEqual(root.dtacctup, datetime(2005, 1, 2))
+        self.assertEqual(root.dtprofup, datetime(2005, 1, 1, tzinfo=UTC))
+        self.assertEqual(root.dtacctup, datetime(2005, 1, 2, tzinfo=UTC))
         self.assertIsInstance(root.fi, FI)
         self.assertEqual(root.sesscookie, 'BADA55')
         self.assertEqual(root.accesskey, 'CAFEBABE')

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -10,6 +10,7 @@ import warnings
 # local imports
 import ofxtools
 from ofxtools.Types import OFXTypeWarning
+from ofxtools.utils import UTC
 
 
 class Base:
@@ -175,35 +176,35 @@ class DateTimeTestCase(unittest.TestCase, Base):
     def test_convert(self):
         t = self.type_()
         # Accept datetime
-        dt = datetime.datetime(2011, 11, 17, 3, 30, 45, 150)
+        dt = datetime.datetime(2011, 11, 17, 3, 30, 45, 150, tzinfo=UTC)
         self.assertEqual(dt, t.convert(dt))
         # Accept date
         d = datetime.date(2011, 11, 17)
         check = datetime.datetime(2011, 11, 17, 0, 0, 0, 0)
         self.assertEqual(check, t.convert(d))
         # Accept YYYYMMDD
-        check = datetime.datetime(2011, 11, 17, 0, 0, 0, 0)
+        check = datetime.datetime(2011, 11, 17, 0, 0, 0, 0, tzinfo=UTC)
         self.assertEqual(check, t.convert('20111117'))
         # Accept YYYYMMDDHHMM
-        check = datetime.datetime(2011, 11, 17, 3, 30, 0, 0)
+        check = datetime.datetime(2011, 11, 17, 3, 30, 0, 0, tzinfo=UTC)
         self.assertEqual(check, t.convert('201111170330'))
         # Accept YYYYMMDDHHMMSS
-        check = datetime.datetime(2011, 11, 17, 3, 30, 45, 0)
+        check = datetime.datetime(2011, 11, 17, 3, 30, 45, 0, tzinfo=UTC)
         self.assertEqual(check, t.convert('20111117033045'))
         # Accept YYYYMMDDHHMMSS.XXX
-        check = datetime.datetime(2011, 11, 17, 3, 30, 45, 150)
+        check = datetime.datetime(2011, 11, 17, 3, 30, 45, 150, tzinfo=UTC)
         self.assertEqual(check, t.convert('20111117033045.150'))
 
         # FIXME - these TZ offset tests only work in CST
 
         # Accept YYYYMMDDHHMMSS.XXX[offset]
-        check = datetime.datetime(2011, 11, 17, 9, 30, 45, 150)
+        check = datetime.datetime(2011, 11, 17, 9, 30, 45, 150, tzinfo=UTC)
         self.assertEqual(check, t.convert('20111117033045.150[-6]'))
         # Accept YYYYMMDDHHMMSS.XXX[offset:TZ]
-        check = datetime.datetime(2011, 11, 17, 9, 30, 45, 150)
+        check = datetime.datetime(2011, 11, 17, 9, 30, 45, 150, tzinfo=UTC)
         self.assertEqual(check, t.convert('20111117033045.150[-6:CST]'))
         # Accept YYYYMMDDHHMMSS.XXX[offset:--]
-        check = datetime.datetime(2011, 11, 17, 3, 30, 45, 150)
+        check = datetime.datetime(2011, 11, 17, 3, 30, 45, 150, tzinfo=UTC)
         self.assertEqual(check, t.convert('20111117033045.150[-:CST]'))
 
     def test_convert_illegal(self):


### PR DESCRIPTION
This pretty much makes sure that what goes up is UTC and what comes out is UTC.  It doesn't tell you what timezone the server responded in.

If you pass in naive times it assumes you mean local time.

Fixes #6 
