### PR TITLE
tz should be tzinfo

### DIFF
--- a/ofxtools/Client.py
+++ b/ofxtools/Client.py
@@ -154,7 +154,7 @@ class OFXClient(object):
         """
         Package and send OFX profile requests (PROFRQ).
         """
-        dtprofup = datetime.datetime(1990, 1, 1, tz=UTC)
+        dtprofup = datetime.datetime(1990, 1, 1, tzinfo=UTC)
         profrq = PROFRQ(clientrouting='NONE', dtprofup=dtprofup)
         trnuid = uuid.uuid4()
         proftrnrq = PROFTRNRQ(trnuid=trnuid, profrq=profrq)


### PR DESCRIPTION
Otherwise you get the following error:

```
  File "/usr/local/bin/ofxget", line 11, in <module>
    sys.exit(main())
  File "/Users/fergbrain/Library/Python/2.7/lib/python/site-packages/ofxtools-0.5.1-py2.7.egg/ofxtools/Client.py", line 504, in main
    do_profile(args)
  File "/Users/fergbrain/Library/Python/2.7/lib/python/site-packages/ofxtools-0.5.1-py2.7.egg/ofxtools/Client.py", line 374, in do_profile
    close_elements=not args.unclosedelements)
  File "/Users/fergbrain/Library/Python/2.7/lib/python/site-packages/ofxtools-0.5.1-py2.7.egg/ofxtools/Client.py", line 159, in request_profile
    dtprofup = datetime.datetime(1990, 1, 1, tz=UTC)
TypeError: 'tz' is an invalid keyword argument for this function
```
Compiled and works correctly now.