### PR TITLE
Endtag v2

### DIFF
--- a/ofxtools/Client.py
+++ b/ofxtools/Client.py
@@ -154,7 +154,7 @@ class OFXClient(object):
         """
         Package and send OFX profile requests (PROFRQ).
         """
-        dtprofup = datetime.datetime(1990, 1, 1, tz=UTC)
+        dtprofup = datetime.datetime(1990, 1, 1, tzinfo=UTC)
         profrq = PROFRQ(clientrouting='NONE', dtprofup=dtprofup)
         trnuid = uuid.uuid4()
         proftrnrq = PROFTRNRQ(trnuid=trnuid, profrq=profrq)

--- a/ofxtools/Client.py
+++ b/ofxtools/Client.py
@@ -252,7 +252,7 @@ class OFXClient(object):
                 raise ValueError(msg)
             data += tostring_unclosed_elements(tree)
         else:
-            data += ET.tostring(tree, encoding='unicode')
+            data += ET.tostring(tree, encoding='utf-8')
 
         if dryrun:
             return BytesIO(data.encode("ascii"))

--- a/ofxtools/Client.py
+++ b/ofxtools/Client.py
@@ -154,7 +154,7 @@ class OFXClient(object):
         """
         Package and send OFX profile requests (PROFRQ).
         """
-        dtprofup = datetime.date(1990, 1, 1)
+        dtprofup = datetime.datetime(1990, 1, 1, tz=UTC)
         profrq = PROFRQ(clientrouting='NONE', dtprofup=dtprofup)
         trnuid = uuid.uuid4()
         proftrnrq = PROFTRNRQ(trnuid=trnuid, profrq=profrq)

--- a/ofxtools/Client.py
+++ b/ofxtools/Client.py
@@ -156,11 +156,8 @@ class OFXClient(object):
         """
         Package and send OFX profile requests (PROFRQ).
         """
-<<<<<<< HEAD
+
         dtprofup = datetime.datetime(1990, 1, 1, tzinfo=UTC)
-=======
-        dtprofup = datetime.datetime(1990, 1, 1, tz=UTC)
->>>>>>> Client.py request_profile datetime.date -> datetime.datetime(tz=UTC)
         profrq = PROFRQ(clientrouting='NONE', dtprofup=dtprofup)
         trnuid = uuid.uuid4()
         proftrnrq = PROFTRNRQ(trnuid=trnuid, profrq=profrq)

--- a/ofxtools/Client.py
+++ b/ofxtools/Client.py
@@ -156,7 +156,11 @@ class OFXClient(object):
         """
         Package and send OFX profile requests (PROFRQ).
         """
+<<<<<<< HEAD
         dtprofup = datetime.datetime(1990, 1, 1, tzinfo=UTC)
+=======
+        dtprofup = datetime.datetime(1990, 1, 1, tz=UTC)
+>>>>>>> Client.py request_profile datetime.date -> datetime.datetime(tz=UTC)
         profrq = PROFRQ(clientrouting='NONE', dtprofup=dtprofup)
         trnuid = uuid.uuid4()
         proftrnrq = PROFTRNRQ(trnuid=trnuid, profrq=profrq)

--- a/tests/test_models_ofx.py
+++ b/tests/test_models_ofx.py
@@ -59,7 +59,6 @@ class OfxTestCase(unittest.TestCase, base.TestAggregate):
     def testUnsupported(self):
         root = Aggregate.from_etree(self.root)
         unsupported = sorted(list(root.unsupported.keys()))
-        print(unsupported)
         self.assertEqual(unsupported, self.unsupported)
         for unsupp in unsupported:
             setattr(root, unsupp, 'FOOBAR')


### PR DESCRIPTION
Fixes two things:
1) `tz` should be `tzinfo`
2) `encoding='unicode'` should be `encoding='utf-8'`

I've verified this works with BECU.