### PR TITLE
Changed Datetime REGEX OFX Spec

### DIFF
--- a/ofxtools/Types.py
+++ b/ofxtools/Types.py
@@ -360,7 +360,7 @@ class DateTime(Element):
                        (
                             (?P<hour>\d\d)(?P<minute>\d\d)((?P<second>\d\d))?
                             (
-                                \.(?P<millisecond>\d\d\d)
+                                (\.(?P<millisecond>\d\d\d))?
                                 (
                                     \[(?P<gmt_offset_hours>[0-9-+]+)
                                     (


### PR DESCRIPTION
I was following the Parser tutorials in the docs: https://ofxtools.readthedocs.io/en/latest/parser.html

```ofx = parser.convert()``` was failing with at line 395 in _convert_str with the following error
```ValueError: 20190213120000[0:GMT] does not conform to OFX formats for datetime```

Found the problem with the timestamp as shown below

I was pulling cc data from Chase and my transactions DatePosted Timestamps were missing the _millisecond group_ that appears before the timezone tag
```
<DTPOSTED>20190213120000[0:GMT]</DTPOSTED>
```

All other Timestamp Tags included the **millisecond group** as show below

```
<DTSTART>20181227152201.530[-5:EST]</DTSTART>
<DTEND>20190426152201.530[-4:EDT]</DTEND>
<DTSERVER>20190426152201.255[-4:EDT]</DTSERVER>
<DTASOF>20190426080000.000[-4:EDT]</DTASOF>
```

I have have prepared these changes and attached the following reports: 
[make_tests.txt](https://github.com/csingley/ofxtools/files/3123646/make_tests.txt)
[coverage_report.txt](https://github.com/csingley/ofxtools/files/3123647/coverage_report.txt)


**Note:** 
There is another OFX Spec locations with this same regex pattern, I have not altered the pattern at this additional location but it can be found here File: ofxtools/Types.py at Line: 476
