### PR TITLE
https://github.com/csingley/ofxtools/issues/70

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -74,7 +74,7 @@ is in `development mode`_:
     $ git clone https://github.com/csingley/ofxtools.git
     $ cd ofxtools
     $ pip install -e .
-    $ pip install -r ofxtools/requirements-development.txt
+    $ pip install -r requirements-development.txt
 
 
 Extra goodies


### PR DESCRIPTION
Fix doc, once we are in ofxtools directory, we just need to refer to the file requirements-development.txt (and not ofxtools/requirements-development.txt)