### PR TITLE
https://github.com/csingley/ofxtools/issues/73

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,13 @@ test:
 	python `which nosetests` -dsv --nologcapture --with-coverage --cover-package ofxtools tests/*.py
 
 clean:
-	find -regex '.*\.pyc' -exec rm {} \;
-	find -regex '.*~' -exec rm {} \;
+	find . -name '*\.pyc' -exec rm '{}' \;
+	find . -name '.*~' -exec rm '{}' \;
+	#find -regex '.*\.pyc' -exec rm {} \;
+	#find -regex '.*~' -exec rm {} \;
 	rm -rf reg-settings.py
 	rm -rf MANIFEST dist build *.egg-info
-	rm coverage.xml
+	rm -f coverage.xml
 
 install:
 	make clean


### PR DESCRIPTION
On my mac, find does not know about -regex flag. I am proposing the following change to find
	find . -name '*\.pyc' -exec rm '{}' \;
	find . -name '.*~' -exec rm '{}' \;

and add a -f flag in case file coverage.xml is not there