### PR TITLE
Fixing build failing due to black

### DIFF
--- a/ofxtools/Types.py
+++ b/ofxtools/Types.py
@@ -492,7 +492,9 @@ class DateTime(Element):
         # microseconds, then insert milliseconds into string format template.
         millisecond = round(value.microsecond / 1000)  # 99500-99999 round to 1000
         second_delta, millisecond = divmod(millisecond, 1000)
-        value += datetime.timedelta(seconds=second_delta)  # Push seconds dial if necessary
+        value += datetime.timedelta(
+            seconds=second_delta
+        )  # Push seconds dial if necessary
 
         millisec_str = "{0:03d}".format(millisecond)
         fmt = "%Y%m%d%H%M%S.{}[0:GMT]".format(millisec_str)


### PR DESCRIPTION
https://api.travis-ci.org/v3/job/685719134/log.txt

```
black --check .
would reformat /home/travis/build/csingley/ofxtools/ofxtools/Types.py
Oh no! ðŸ’¥ ðŸ’” ðŸ’¥
1 file would be reformatted, 94 files would be left unchanged.
Makefile:2: recipe for target 'test' failed
make: *** [test] Error 1
travis_time:end:04401dbf:start=1589211617811461855,finish=1589211628504921190,duration=10693459335,event=script
[0K[31;1mThe command "make test" exited with 2.[0m


Done. Your build exited with 1.
```