### PR TITLE
Use NagString for INV401K.employername

### DIFF
--- a/ofxtools/models/invest/stmt.py
+++ b/ofxtools/models/invest/stmt.py
@@ -31,6 +31,7 @@ __all__ = [
 
 from ofxtools.Types import (
     Bool,
+    NagString,
     String,
     Integer,
     OneOf,
@@ -256,7 +257,7 @@ class INV401KSUMMARY(Aggregate):
 class INV401K(Aggregate):
     """ OFX section 13.9.3 """
 
-    employername = String(32, required=True)
+    employername = NagString(32, required=True)
     planid = String(32)
     planjoindate = DateTime()
     employercontactinfo = String(255)


### PR DESCRIPTION
Some FIs use an employername longer than 32 characters

Addresses: https://github.com/csingley/ofxtools/issues/96