### PR TITLE
ofxget: Add --nonewfileuid option

### DIFF
--- a/ofxtools/scripts/ofxget.py
+++ b/ofxtools/scripts/ofxget.py
@@ -222,6 +222,12 @@ def add_subparser(
             default=None,
             help="Skip SSL certificate verification",
         )
+        parser.add_argument(
+            "--nonewfileuid",
+            action="store_true",
+            default=None,
+            help="Use 'NONE' instead of generating a UID for NEWFILEUID in header",
+        )
 
     if format:
         parser.add_argument(
@@ -554,7 +560,9 @@ def request_profile(args: ArgsType) -> None:
     client = init_client(args)
 
     with client.request_profile(
-        dryrun=args["dryrun"], verify_ssl=not args["unsafe"]
+        dryrun=args["dryrun"],
+        verify_ssl=not args["unsafe"],
+        gen_newfileuid=not args["nonewfileuid"],
     ) as f:
         response = f.read()
 
@@ -593,7 +601,11 @@ def _request_acctinfo(args: ArgsType, password: str) -> BytesIO:
     dtacctup = args["dtacctup"] or datetime.datetime(1990, 12, 31, tzinfo=utils.UTC)
 
     with client.request_accounts(
-        password, dtacctup, dryrun=args["dryrun"], verify_ssl=not args["unsafe"]
+        password,
+        dtacctup,
+        dryrun=args["dryrun"],
+        verify_ssl=not args["unsafe"],
+        gen_newfileuid=not args["nonewfileuid"],
     ) as f:
         response = f.read()
 
@@ -688,7 +700,11 @@ def request_stmt(args: ArgsType) -> None:
 
     client = init_client(args)
     with client.request_statements(
-        password, *stmtrqs, dryrun=args["dryrun"], verify_ssl=not args["unsafe"]
+        password,
+        *stmtrqs,
+        dryrun=args["dryrun"],
+        verify_ssl=not args["unsafe"],
+        gen_newfileuid=not args["nonewfileuid"],
     ) as f:
         response = f.read()
 
@@ -739,7 +755,11 @@ def request_stmtend(args: ArgsType) -> None:
 
     client = init_client(args)
     with client.request_statements(
-        password, *stmtendrqs, dryrun=args["dryrun"], verify_ssl=not args["unsafe"]
+        password,
+        *stmtendrqs,
+        dryrun=args["dryrun"],
+        verify_ssl=not args["unsafe"],
+        gen_newfileuid=not args["nonewfileuid"],
     ) as f:
         response = f.read()
 
@@ -767,6 +787,7 @@ def request_tax1099(args: ArgsType) -> None:
         recid=args["recid"],
         dryrun=args["dryrun"],
         verify_ssl=not args["unsafe"],
+        gen_newfileuid=not args["nonewfileuid"],
     ) as f:
         response = f.read()
 
@@ -843,6 +864,7 @@ DEFAULTS: Dict[str, ArgType] = {
     "write": False,
     "savepass": False,
     "nokeyring": False,
+    "nonewfileuid": False,
 }
 
 
@@ -869,6 +891,7 @@ configurable_srvr = (
     "appid",
     "appver",
     "language",
+    "nonewfileuid",
 )
 CONFIGURABLE_SRVR = {k: type(v) for k, v in DEFAULTS.items() if k in configurable_srvr}
 

--- a/tests/test_ofxget.py
+++ b/tests/test_ofxget.py
@@ -85,6 +85,7 @@ class MakeArgParserTestCase(unittest.TestCase):
             "all": False,
             "write": False,
             "savepass": False,
+            "nonewfileuid": False,
         }
 
     def testScanProfile(self):
@@ -245,6 +246,7 @@ class MakeArgParserTestCase(unittest.TestCase):
                     {
                         "dryrun": self.args["dryrun"],
                         "verify_ssl": not self.args["unsafe"],
+                        "gen_newfileuid": not self.args["nonewfileuid"],
                     },
                 )
 
@@ -301,7 +303,11 @@ class MakeArgParserTestCase(unittest.TestCase):
 
             self.assertEqual(
                 kwargs,
-                {"dryrun": self.args["dryrun"], "verify_ssl": not self.args["unsafe"]},
+                {
+                    "dryrun": self.args["dryrun"],
+                    "verify_ssl": not self.args["unsafe"],
+                    "gen_newfileuid": not self.args["nonewfileuid"],
+                },
             )
 
     def test_RequestAcctinfoOverrideDtacctup(self):
@@ -324,7 +330,11 @@ class MakeArgParserTestCase(unittest.TestCase):
 
             self.assertEqual(
                 kwargs,
-                {"dryrun": self.args["dryrun"], "verify_ssl": not self.args["unsafe"]},
+                {
+                    "dryrun": self.args["dryrun"],
+                    "verify_ssl": not self.args["unsafe"],
+                    "gen_newfileuid": not self.args["nonewfileuid"],
+                },
             )
 
     def testMergeAcctinfo(self):
@@ -456,7 +466,14 @@ class MakeArgParserTestCase(unittest.TestCase):
                             ),
                         ],
                     )
-                    self.assertEqual(kwargs, {"dryrun": False, "verify_ssl": True})
+                    self.assertEqual(
+                        kwargs,
+                        {
+                            "dryrun": False,
+                            "verify_ssl": True,
+                            "gen_newfileuid": True,
+                        },
+                    )
 
                     args, kwargs = mock_print.call_args
                     self.assertEqual(len(args), 1)
@@ -567,7 +584,14 @@ class MakeArgParserTestCase(unittest.TestCase):
                         ),
                     ],
                 )
-                self.assertEqual(kwargs, {"dryrun": True, "verify_ssl": True})
+                self.assertEqual(
+                    kwargs,
+                    {
+                        "dryrun": True,
+                        "verify_ssl": True,
+                        "gen_newfileuid": True,
+                    },
+                )
 
                 args, kwargs = mock_print.call_args
                 self.assertEqual(len(args), 1)
@@ -680,7 +704,14 @@ class MakeArgParserTestCase(unittest.TestCase):
                             ),
                         ],
                     )
-                    self.assertEqual(kwargs, {"dryrun": False, "verify_ssl": True})
+                    self.assertEqual(
+                        kwargs,
+                        {
+                            "dryrun": False,
+                            "verify_ssl": True,
+                            "gen_newfileuid": True,
+                        },
+                    )
 
                     args, kwargs = mock_print.call_args
                     self.assertEqual(len(args), 1)
@@ -718,6 +749,7 @@ class MakeArgParserTestCase(unittest.TestCase):
                             "recid": "67890",
                             "dryrun": False,
                             "verify_ssl": True,
+                            "gen_newfileuid": True,
                         },
                     )
 


### PR DESCRIPTION
This allows you to set `NEWFILEUID="NONE"` in the header for FIs which
don't like it being an actual UID.

Closes https://github.com/csingley/ofxtools/issues/98