### PR TITLE
Make User-Agent header configurable

### DIFF
--- a/ofxtools/Client.py
+++ b/ofxtools/Client.py
@@ -182,6 +182,7 @@ class OFXClient:
     appid: str = "QWIN"
     appver: str = "2700"
     language: str = "ENG"
+    useragent: str = ""
 
     # Formatting defaults
     prettyprint: bool = False
@@ -218,6 +219,7 @@ class OFXClient:
         close_elements: Optional[bool] = None,
         bankid: Optional[str] = None,
         brokerid: Optional[str] = None,
+        useragent: Optional[str] = None,
     ):
 
         self.url = url
@@ -235,6 +237,7 @@ class OFXClient:
             "close_elements",
             "bankid",
             "brokerid",
+            "useragent",
         ]:
             value = locals()[attr]
             if value is not None:
@@ -261,7 +264,7 @@ class OFXClient:
         # identify themselves in the ``User-Agent`` header,
         # which apparently displeases some FIs
         return {
-            "User-Agent": "",
+            "User-Agent": self.useragent,
             "Content-type": mimetype,
             "Accept": "*/*, {}".format(mimetype),
         }

--- a/ofxtools/scripts/ofxget.py
+++ b/ofxtools/scripts/ofxget.py
@@ -222,6 +222,11 @@ def add_subparser(
             default=None,
             help="Skip SSL certificate verification",
         )
+        parser.add_argument(
+            "--useragent",
+            dest="useragent",
+            help="Value to use in HTTP 'User-Agent' header (defaults to empty string)",
+        )
 
     if format:
         parser.add_argument(
@@ -548,6 +553,7 @@ def init_client(args: ArgsType) -> OFXClient:
         close_elements=not args["unclosedelements"],
         bankid=args["bankid"] or None,
         brokerid=args["brokerid"] or None,
+        useragent=args["useragent"] or None,
     )
     logger.debug(f"Initialized {client}")
     return client
@@ -865,6 +871,7 @@ DEFAULTS: Dict[str, ArgType] = {
     "savepass": False,
     "nokeyring": False,
     "nonewfileuid": False,
+    "useragent": "",
 }
 
 
@@ -892,6 +899,7 @@ configurable_srvr = (
     "appver",
     "language",
     "nonewfileuid",
+    "useragent",
 )
 CONFIGURABLE_SRVR = {k: type(v) for k, v in DEFAULTS.items() if k in configurable_srvr}
 

--- a/tests/test_ofxget.py
+++ b/tests/test_ofxget.py
@@ -86,6 +86,7 @@ class MakeArgParserTestCase(unittest.TestCase):
             "write": False,
             "savepass": False,
             "nonewfileuid": False,
+            "useragent": "",
         }
 
     def testScanProfile(self):


### PR DESCRIPTION
I've come across an FI which dislikes the HTTP User-Agent header being empty (coincidentally the same that doesn't like NEWFILEUID), but others have found FIs which dislike it containing different values... so is it time to parameterize it? This PR leaves the default behavior unchanged, but adds a parameter to `OFXClient` and a matching argument to `ofxget` to support overriding the user agent

This commit allows me to successfully make requests to this FI with ofxtools.

Question: Given our previous discussion about how to organize the arguments in `ofxget` - where would you like this one? I'm not sure I would think of an HTTP header as a 'formatting' argument, but I think it likely applies to the same set of subcommands...