### PR TITLE
Add cookie handling to OFXClient

### DIFF
--- a/ofxtools/Client.py
+++ b/ofxtools/Client.py
@@ -58,7 +58,17 @@ from io import BytesIO
 import itertools
 from operator import attrgetter, itemgetter
 from functools import singledispatch
-from typing import Dict, Union, Optional, Tuple, Iterator, NamedTuple, BinaryIO, Type, Callable
+from typing import (
+    Dict,
+    Union,
+    Optional,
+    Tuple,
+    Iterator,
+    NamedTuple,
+    BinaryIO,
+    Type,
+    Callable,
+)
 
 
 # local imports
@@ -652,10 +662,12 @@ class OFXClient:
         # TESTME
         if verify_ssl is False:
             if self.url_opener != urllib_request.urlopen:
-                raise Exception("Can only skip ssl verification when using default urlopener!")
+                raise Exception(
+                    "Can only skip ssl verification when using default urlopener!"
+                )
 
             logger.warning("Skipping SSL certificate verification")
-            kwargs['context'] = ssl._create_unverified_context()
+            kwargs["context"] = ssl._create_unverified_context()
 
         response = self.url_opener(req, **kwargs)
         return BytesIO(response.read())

--- a/ofxtools/Client.py
+++ b/ofxtools/Client.py
@@ -193,7 +193,7 @@ class OFXClient:
     brokerid: Optional[str] = None
 
     # URL opener
-    url_opener: Optional[Callable] = urllib_request.urlopen
+    url_opener: Callable = urllib_request.urlopen
 
     def __repr__(self) -> str:
         r = (

--- a/ofxtools/Client.py
+++ b/ofxtools/Client.py
@@ -657,21 +657,23 @@ class OFXClient:
 
         kwargs = dict(timeout=timeout)
 
-        # By default, verify SSL certificate signatures
-        # Cf. PEP 476
-        # TESTME
-        if verify_ssl is False:
-            if self.url_opener is not None:
-                raise Exception(
-                    "Can only skip ssl verification when using default urlopener!"
-                )
-
-            logger.warning("Skipping SSL certificate verification")
-            kwargs["context"] = ssl._create_unverified_context()
-
         url_opener = self.url_opener
         if url_opener is None:
             url_opener = urllib_request.urlopen
+
+            # By default, verify SSL certificate signatures
+            # Cf. PEP 476
+            # TESTME
+            if verify_ssl is False:
+                logger.warning("Skipping SSL certificate verification")
+                kwargs["context"] = ssl._create_unverified_context()
+            else:
+                kwargs["context"] = ssl.create_default_context()
+        else:
+            if verify_ssl is False:
+                raise Exception(
+                    "Can only skip ssl verification when using default urlopener!"
+                )
 
         response = url_opener(req, **kwargs)
         return BytesIO(response.read())

--- a/ofxtools/Client.py
+++ b/ofxtools/Client.py
@@ -647,13 +647,13 @@ class OFXClient:
 
         kwargs = dict(timeout=timeout)
 
+        # By default, verify SSL certificate signatures
+        # Cf. PEP 476
+        # TESTME
         if verify_ssl is False:
             if self.url_opener != urllib_request.urlopen:
                 raise Exception("Can only skip ssl verification when using default urlopener!")
 
-            # By default, verify SSL certificate signatures
-            # Cf. PEP 476
-            # TESTME
             logger.warning("Skipping SSL certificate verification")
             kwargs['context'] = ssl._create_unverified_context()
 

--- a/ofxtools/Client.py
+++ b/ofxtools/Client.py
@@ -647,16 +647,15 @@ class OFXClient:
 
         kwargs = dict(timeout=timeout)
 
-        if not verify_ssl:
+        if verify_ssl is False:
             if self.url_opener != urllib_request.urlopen:
                 raise Exception("Can only skip ssl verification when using default urlopener!")
 
             # By default, verify SSL certificate signatures
             # Cf. PEP 476
             # TESTME
-            if verify_ssl is False:
-                logger.warning("Skipping SSL certificate verification")
-                kwargs['context'] = ssl._create_unverified_context()
+            logger.warning("Skipping SSL certificate verification")
+            kwargs['context'] = ssl._create_unverified_context()
 
         response = self.url_opener(req, **kwargs)
         return BytesIO(response.read())

--- a/ofxtools/Client.py
+++ b/ofxtools/Client.py
@@ -58,7 +58,7 @@ from io import BytesIO
 import itertools
 from operator import attrgetter, itemgetter
 from functools import singledispatch
-from typing import Dict, Union, Optional, Tuple, Iterator, NamedTuple, BinaryIO, Type
+from typing import Dict, Union, Optional, Tuple, Iterator, NamedTuple, BinaryIO, Type, Callable
 
 
 # local imports
@@ -192,6 +192,9 @@ class OFXClient:
     bankid: Optional[str] = None
     brokerid: Optional[str] = None
 
+    # URL opener
+    url_opener: Optional[Callable] = urllib_request.urlopen
+
     def __repr__(self) -> str:
         r = (
             "{cls}(url={url!r}, userid={userid!r}, clientuid={clientuid!r}, "
@@ -220,6 +223,7 @@ class OFXClient:
         bankid: Optional[str] = None,
         brokerid: Optional[str] = None,
         useragent: Optional[str] = None,
+        url_opener: Optional[Callable] = None,
     ):
 
         self.url = url
@@ -238,6 +242,7 @@ class OFXClient:
             "bankid",
             "brokerid",
             "useragent",
+            "url_opener",
         ]:
             value = locals()[attr]
             if value is not None:
@@ -636,18 +641,24 @@ class OFXClient:
         req = urllib_request.Request(
             self.url, method="POST", data=request, headers=self.http_headers
         )
-        # By default, verify SSL certificate signatures
-        # Cf. PEP 476
-        # TESTME
-        if verify_ssl is False:
-            logger.warning("Skipping SSL certificate verification")
-            ssl_context = ssl._create_unverified_context()
-        else:
-            ssl_context = ssl.create_default_context()
 
         if timeout is None:
             timeout = socket._GLOBAL_DEFAULT_TIMEOUT  # type: ignore
-        response = urllib_request.urlopen(req, timeout=timeout, context=ssl_context)
+
+        kwargs = dict(timeout=timeout)
+
+        if not verify_ssl:
+            if self.url_opener != urllib_request.urlopen:
+                raise Exception("Can only skip ssl verification when using default urlopener!")
+
+            # By default, verify SSL certificate signatures
+            # Cf. PEP 476
+            # TESTME
+            if verify_ssl is False:
+                logger.warning("Skipping SSL certificate verification")
+                kwargs['context'] = ssl._create_unverified_context()
+
+        response = self.url_opener(req, **kwargs)
         return BytesIO(response.read())
 
     def serialize(

--- a/ofxtools/Client.py
+++ b/ofxtools/Client.py
@@ -203,7 +203,7 @@ class OFXClient:
     brokerid: Optional[str] = None
 
     # URL opener
-    url_opener: Callable = urllib_request.urlopen
+    url_opener: Optional[Callable] = None
 
     def __repr__(self) -> str:
         r = (
@@ -661,7 +661,7 @@ class OFXClient:
         # Cf. PEP 476
         # TESTME
         if verify_ssl is False:
-            if self.url_opener != urllib_request.urlopen:
+            if self.url_opener is not None:
                 raise Exception(
                     "Can only skip ssl verification when using default urlopener!"
                 )
@@ -669,7 +669,11 @@ class OFXClient:
             logger.warning("Skipping SSL certificate verification")
             kwargs["context"] = ssl._create_unverified_context()
 
-        response = self.url_opener(req, **kwargs)
+        url_opener = self.url_opener
+        if url_opener is None:
+            url_opener = urllib_request.urlopen
+
+        response = url_opener(req, **kwargs)
         return BytesIO(response.read())
 
     def serialize(


### PR DESCRIPTION
Some OFX gateways require non-standard http requests, e.g. preserving
cookies across requests or other custom headers. Instead of trying to
encode every possible custom transport sideband requirement, allow
user to provide custom URL opener to suit their specific use case,
while we only handle the standard OFX requirements.

This has the added benefit of allowing the user to use non-http
transports to retrieve OFX data, as well as potentially easing
testing.