### PR TITLE
add --password to help with scripting.

### DIFF
--- a/ofxtools/scripts/ofxget.py
+++ b/ofxtools/scripts/ofxget.py
@@ -292,6 +292,9 @@ def add_format_group(parser: argparse.ArgumentParser) -> argparse._ArgumentGroup
 def add_signon_group(parser: argparse.ArgumentParser) -> argparse._ArgumentGroup:
     group = parser.add_argument_group(title="signon options")
     group.add_argument("-u", "--user", help="FI login username")
+    group.add_argument("--password",
+            help="Password. Used for scripting. Eg: --password $(/usr/bin/pass mybank/login). Use with "
+            "caution to avoid exposing passwords to the shell and its history.")
     group.add_argument(
         "--clientuid",
         nargs=0,
@@ -845,6 +848,7 @@ DEFAULTS: Dict[str, ArgType] = {
     "unclosedelements": False,
     "pretty": False,
     "user": "",
+    "password": "",
     "clientuid": "",
     "checking": [],
     "savings": [],
@@ -1510,6 +1514,8 @@ def get_passwd(args: ArgsType) -> str:
     if args["dryrun"]:
         logger.debug("Dry run; using dummy password")
         password = "{:0<32}".format("anonymous")
+    elif args["password"]:
+        return args["password"]
     else:
         password = ""
         if all(


### PR DESCRIPTION
Support for password input via command line (or generic password input) #110 