### PR TITLE
Handle negative fractional timezone offsets.

### DIFF
--- a/ofxtools/Types.py
+++ b/ofxtools/Types.py
@@ -535,10 +535,11 @@ def format_datetime(format: str, value: datetime.datetime) -> str:
 
     # OFX takes the UTC offset formatted as +h[.mm].
     offset_mins = utcoffset // datetime.timedelta(minutes=1)
-    hours, mins = divmod(offset_mins, 60)
-    tz = f"{hours:+d}"
+    hours, mins = divmod(abs(offset_mins), 60)
+    sign = "-" if offset_mins < 0 else "+"
+    tz = f"{sign}{hours:d}"
     if mins != 0:
-        tz += f".{abs(mins):02d}"
+        tz += f".{mins:02d}"
 
     # Note that tzname() is permitted to return None.
     tzname = value.tzname()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -429,6 +429,7 @@ class TestingTimezone(datetime.tzinfo):
 
 CST = TestingTimezone("CST", datetime.timedelta(hours=-6))
 IST = TestingTimezone("IST", datetime.timedelta(hours=5, minutes=30))
+NST = TestingTimezone("NST", datetime.timedelta(hours=-3.5))
 
 
 class DateTimeTestCase(unittest.TestCase, Base):
@@ -498,6 +499,9 @@ class DateTimeTestCase(unittest.TestCase, Base):
 
         check = datetime.datetime(2007, 1, 1, tzinfo=IST)
         self.assertEqual(t.unconvert(check), "20070101000000.000[+5.30:IST]")
+
+        check = datetime.datetime(2007, 1, 1, tzinfo=NST)
+        self.assertEqual(t.unconvert(check), "20070101000000.000[-3.30:NST]")
 
     def test_unconvert_round_microseconds(self):
         # Round up microseconds above 999499; increment seconds (Issue #80)


### PR DESCRIPTION
Python's `divmod` function rounds towards negative infinity, so timezones with a
fractional negative offset would be off by one.

Add a test using Newfoundland Standard Time which demonstrates this problem.