### PR TITLE
[WIP] Feature/flexible header parser

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Open Financial Exchange (OFX) Tools for Python
     :target: https://coveralls.io/github/csingley/ofxtools?branch=master
 
 .. image:: https://img.shields.io/badge/dependencies-None-green.svg
-    :target: https://github.com/csingley/ofxtools/blob/master/requirements.txt 
+    :target: https://github.com/csingley/ofxtools/blob/master/requirements.txt
 
 .. image:: https://badge.fury.io/py/ofxtools.svg
     :target: https://badge.fury.io/py/ofxtools
@@ -81,7 +81,7 @@ a `bug tracker`_.
 
 Installation Dependencies
 -------------------------
-``ofxtools`` requires Python version 3.7+, and depends only on the standard
+``ofxtools`` requires Python version 3.8+, and depends only on the standard
 libary (no external dependencies).
 
 **NOTE: As of version 0.6, ofxtools no longer supports Python version 2,


### PR DESCRIPTION
(This is a work in progress, please read the whole message and do not merge yet.)

The OFX generated by @nubank lacks the `CHARSET` header, like in:

```
OFXHEADER:100
DATA:OFXSGML
VERSION:102
SECURITY:NONE
ENCODING:UTF-8
COMPRESSION:NONE
OLDFILEUID:NONE
NEWFILEUID:NONE
<OFX>
<SIGNONMSGSRSV1>
<SONRS>
<STATUS>
<CODE>0</CODE>
<SEVERITY>INFO</SEVERITY>
</STATUS>
<DTSERVER>20210603013909[0:GMT]</DTSERVER>
<LANGUAGE>POR</LANGUAGE>
<FI>
<ORG>NU PAGAMENTOS S.A.</ORG>
<FID>260</FID>
</FI>
</SONRS>
</SIGNONMSGSRSV1>
<BANKMSGSRSV1>
<STMTTRNRS>
<TRNUID>1</TRNUID>
<STATUS>
<CODE>0</CODE>
<SEVERITY>INFO</SEVERITY>
</STATUS>
<STMTRS>
<CURDEF>BRL</CURDEF>
<BANKACCTFROM>
<BANKID>0260</BANKID>
<BRANCHID>1</BRANCHID>
<ACCTID>123-4</ACCTID>
<ACCTTYPE>CHECKING</ACCTTYPE>
</BANKACCTFROM>
<BANKTRANLIST>
<DTSTART>20200201000000[0:GMT]</DTSTART>
<DTEND>20200229000000[0:GMT]</DTEND>
</BANKTRANLIST>
<LEDGERBAL>
<BALAMT>0.00</BALAMT>
<DTASOF>20200229000000[0:GMT]</DTASOF>
</LEDGERBAL>
</STMTRS>
</STMTTRNRS>
</BANKMSGSRSV1>
</OFX>
```

I've got an error parsing this file with ofxtools:

Code for `test.py`:
```python
from ofxtools.Parser import OFXTree

with open("test.ofx", "rb") as fobj:
    parser = OFXTree()
    parser.parse(fobj)
    statement = parser.convert().statements[0]
    print(statement)
```
Error:
```
Traceback (most recent call last):
  File "test.py", line 5, in <module>
    parser.parse(fobj)
  File "/home/turicas/projects/ofxtools/ofxtools/Parser.py", line 85, in parse
    self.header, message = self._read(source)
  File "/home/turicas/projects/ofxtools/ofxtools/Parser.py", line 118, in _read
    header, message = parse_header(source)
  File "/home/turicas/projects/ofxtools/ofxtools/header.py", line 294, in parse_header
    header, header_end_index = OFXHeaderV1.parse(rawheader)
  File "/home/turicas/projects/ofxtools/ofxtools/header.py", line 81, in parse
    raise OFXHeaderError(f"OFX header is malformed:\n{rawheader}")
ofxtools.header.OFXHeaderError: OFX header is malformed:
OFXHEADER:100

DATA:OFXSGML
VERSION:102
SECURITY:NONE
ENCODING:UTF-8
COMPRESSION:NONE
OLDFILEUID:NONE
NEWFILEUID:NONE
<OFX>
```

The rest of the file is correct and if I manually add `CHARSET:NONE` between `ENCODING` and `COMPRESSION`, it works perfectly:

```shell
$ sed -i 's/ENCODING:UTF-8/ENCODING:UTF-8\nCHARSET:NONE/' test.ofx
$ python test.py 
<STMTRS(curdef='BRL', bankacctfrom=<BANKACCTFROM(bankid='0260', branchid='1', acctid='123-4', accttype='CHECKING')>, banktranlist=<BANKTRANLIST dtstart='2020-02-01 00:00:00+00:00' dtend='2020-02-29 00:00:00+00:00' len=0>, ledgerbal=<LEDGERBAL(balamt=Decimal('0.00'), dtasof=datetime.datetime(2020, 2, 29, 0, 0, tzinfo=<UTC>))>)>
```

In this PR I changed the way V1 header is parsed, but a test is still failing and I'd like some help fixing it. I've also "skipped" the whole logic behind `header_end_index` and it may not work in other cases.