### PR TITLE
Catch ofxget scan exceptions, allow V1 headers to support later versions

### DIFF
--- a/ofxtools/header.py
+++ b/ofxtools/header.py
@@ -90,7 +90,7 @@ class OFXHeaderV1(OFXHeaderBase):
 
     ofxheader = Types.OneOf(100)
     data = Types.OneOf("OFXSGML")
-    version = Types.OneOf(102, 103, 151, 160)
+    version = Types.Integer(length=3)
     security = Types.OneOf("NONE", "TYPE1")
     encoding = Types.OneOf("USASCII", "UNICODE", "UTF-8")
     # DRY - mapping of CHARSET: codec used below in codec()
@@ -153,7 +153,7 @@ class OFXHeaderV1(OFXHeaderBase):
         try:
             self.ofxheader = int(ofxheader or 100)
             self.data = data or "OFXSGML"
-            self.version = int(version)
+            self.version = int(version or 102)
             self.security = security or "NONE"
             self.encoding = encoding or "USASCII"
             self.charset = charset or "NONE"

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -77,9 +77,10 @@ class OFXHeaderV1TestCase(unittest.TestCase, OFXHeaderTestMixin):
     headerClass = ofxtools.header.OFXHeaderV1
     defaultVersion = 102
     valid = {
-        "version": (102, 103, 151, 160),
         "ofxheader": (100,),
         "data": ("OFXSGML",),
+        # OFXHeader version 100 supports message sets from later versions
+        "version": (102, 103, 151, 160, 200, 203),
         "security": ("NONE", "TYPE1"),
         "encoding": ("USASCII", "UNICODE", "UTF-8"),
         "charset": ("ISO-8859-1", "1252", "NONE"),
@@ -88,9 +89,9 @@ class OFXHeaderV1TestCase(unittest.TestCase, OFXHeaderTestMixin):
         "newfileuid": (str(uuid.uuid4()),),
     }
     invalid = {
-        "version": (123,),
         "ofxheader": (200,),
         "data": ("XML",),
+        "version": (1111,),
         "security": ("TYPE2",),
         "encoding": ("UTF-16",),
         "charset": ("ISO-8859-7",),

--- a/tests/test_ofxget.py
+++ b/tests/test_ofxget.py
@@ -1207,7 +1207,6 @@ class ReadScanResponseTestCase(unittest.TestCase):
 
         # No valid OFX: return False, empty SIGNONINFO parameters
         ofx_errors = [
-            socket.timeout,
             ET.ParseError(),
             Parser.ParseError(),
             header.OFXHeaderError(),


### PR DESCRIPTION
One of my banks returns OFXHeader V100 and VERSION 203 content. 
When ofxget scans with V200 headers, the server returns html error message content which fails OFX header parsing as expected. However the OFXHeaderError exceptions were not caught by ofxget - read_scan_response and the command terminates.
This was preventing me from scanning and getting acct info. Updated ofxget to catch the OFXHeaderErrors.

Secondly, OFXHeaderV1 was updated to relax verification of version. My understanding of the OFX standard is that V1XX can support V2XX messages.

