### PR TITLE
one of my banks does not send a COMPRESSION in V1 header

### DIFF
--- a/ofxtools/header.py
+++ b/ofxtools/header.py
@@ -122,7 +122,7 @@ class OFXHeaderV1(OFXHeaderBase):
             SECURITY:\s*(?P<SECURITY>[\w]+)\s*
             ENCODING:\s*(?P<ENCODING>[A-Z0-9-]+)\s*
             CHARSET:\s*(?P<CHARSET>[\w-]+)\s*
-            COMPRESSION:\s*(?P<COMPRESSION>[A-Z]+)\s*
+            (?:COMPRESSION:\s*(?P<COMPRESSION>[A-Z]+)\s*)?
             OLDFILEUID:\s*(?P<OLDFILEUID>[\w-]+)\s*
             NEWFILEUID:\s*(?P<NEWFILEUID>[\w-]+)
         """,


### PR DESCRIPTION
As the title says, I'm getting OFX V1 files with no COMPRESSION header (from University of Wisconsin Credit Union - UWCU) so made that group optional.