### PR TITLE
Add support for Python 3.12+

### DIFF
--- a/.github/workflows/commit-ofxtools.yml
+++ b/.github/workflows/commit-ofxtools.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v3

--- a/ofxtools/models/profile.py
+++ b/ofxtools/models/profile.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" FI Profile - OFX Section 7 """
+"""FI Profile - OFX Section 7"""
 
 
 __all__ = [

--- a/ofxtools/ofxhome.py
+++ b/ofxtools/ofxhome.py
@@ -21,6 +21,7 @@ import datetime
 import xml.etree.ElementTree as ET
 from xml.sax import saxutils
 import urllib
+import urllib.request
 import urllib.error as urllib_error
 import urllib.parse as urllib_parse
 import re

--- a/ofxtools/scripts/ofxget.py
+++ b/ofxtools/scripts/ofxget.py
@@ -1335,7 +1335,7 @@ def _read_scan_response(
 
 
 def collate_scan_results(
-    scan_results: Iterable[Tuple[OFXVersion, Sequence[MarkupFormat]]]
+    scan_results: Iterable[Tuple[OFXVersion, Sequence[MarkupFormat]]],
 ) -> ScanResult:
     """
     Input ``scan_results`` needs to be a complete set for either OFXv1 or v2,
@@ -1365,7 +1365,7 @@ def collate_scan_results(
 # OFX PARSING
 ###############################################################################
 def verify_status(
-    trnrs: Union[models.SONRS, models.PROFTRNRS, models.ACCTINFOTRNRS]
+    trnrs: Union[models.SONRS, models.PROFTRNRS, models.ACCTINFOTRNRS],
 ) -> None:
     """
     Input a models.Aggregate instance representing a transaction wrapper.

--- a/ofxtools/scripts/ofxget.py
+++ b/ofxtools/scripts/ofxget.py
@@ -1499,7 +1499,7 @@ def fi_index() -> Sequence[Tuple[str, str, str]]:
     names = {id_: name for id_, name in USERCFG["NAMES"].items()}
     cfg_default_sect = USERCFG.default_section  # type: ignore
     servers = [
-        (names.get(sct.get("ofxhome", None), ""), nick, sct.get("ofxhome", "--"))
+        (names.get(sct.get("ofxhome", ""), ""), nick, sct.get("ofxhome", "--"))
         for nick, sct in USERCFG.items()
         if nick not in (cfg_default_sect, "NAMES") and "url" in sct
     ]

--- a/ofxtools/utils.py
+++ b/ofxtools/utils.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Utility functions and classes """
+"""Utility functions and classes"""
 
 # stdlib imports
 import datetime

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,9 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
     keywords=["ofx", "Open Financial Exchange"],
 )

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Common classes reused by unit tests in this package """
+"""Common classes reused by unit tests in this package"""
 
 # stdlib imports
 import unittest

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for ofxtools.Client """
+"""Unit tests for ofxtools.Client"""
 
 # stdlib imports
 import unittest

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for ofxtools.header """
+"""Unit tests for ofxtools.header"""
 
 # stdlib imports
 import unittest

--- a/tests/test_models_base.py
+++ b/tests/test_models_base.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for models/base.py """
+"""Unit tests for models/base.py"""
 # stdlib imports
 import unittest
 import xml.etree.ElementTree as ET

--- a/tests/test_models_billpay_common.py
+++ b/tests/test_models_billpay_common.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for models.billpay.common """
+"""Unit tests for models.billpay.common"""
 # stdlib imports
 import unittest
 from datetime import datetime

--- a/tests/test_models_billpay_list.py
+++ b/tests/test_models_billpay_list.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for models.billpay.common """
+"""Unit tests for models.billpay.common"""
 # stdlib imports
 import unittest
 from xml.etree.ElementTree import Element, SubElement

--- a/tests/test_models_billpay_mail.py
+++ b/tests/test_models_billpay_mail.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for models.billpay.mail"""
+"""Unit tests for models.billpay.mail"""
 # stdlib imports
 import unittest
 import xml.etree.ElementTree as ET

--- a/tests/test_models_billpay_pmt.py
+++ b/tests/test_models_billpay_pmt.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for models.billpay.pmt """
+"""Unit tests for models.billpay.pmt"""
 # stdlib imports
 import unittest
 from xml.etree.ElementTree import Element, SubElement

--- a/tests/test_models_billpay_recur.py
+++ b/tests/test_models_billpay_recur.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for models.billpay.recur """
+"""Unit tests for models.billpay.recur"""
 # stdlib imports
 import unittest
 from decimal import Decimal

--- a/tests/test_models_billpay_sync.py
+++ b/tests/test_models_billpay_sync.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for models.billpay.sync """
+"""Unit tests for models.billpay.sync"""
 # stdlib imports
 import unittest
 import xml.etree.ElementTree as ET

--- a/tests/test_models_common.py
+++ b/tests/test_models_common.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for models.common """
+"""Unit tests for models.common"""
 # stdlib imports
 import unittest
 from datetime import datetime

--- a/tests/test_models_email.py
+++ b/tests/test_models_email.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for models.email """
+"""Unit tests for models.email"""
 # stdlib imports
 import unittest
 from xml.etree.ElementTree import Element, SubElement

--- a/tests/test_models_i18n.py
+++ b/tests/test_models_i18n.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for models/common.py """
+"""Unit tests for models/common.py"""
 # stdlib imports
 import unittest
 from decimal import Decimal

--- a/tests/test_models_invest.py
+++ b/tests/test_models_invest.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for models.invest """
+"""Unit tests for models.invest"""
 # stdlib imports
 import unittest
 from xml.etree.ElementTree import Element, SubElement

--- a/tests/test_models_invest_oo.py
+++ b/tests/test_models_invest_oo.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for models.invest """
+"""Unit tests for models.invest"""
 # stdlib imports
 import unittest
 from xml.etree.ElementTree import Element, SubElement

--- a/tests/test_models_invest_transactions.py
+++ b/tests/test_models_invest_transactions.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for models.invest """
+"""Unit tests for models.invest"""
 # stdlib imports
 import unittest
 from xml.etree.ElementTree import Element, SubElement

--- a/tests/test_models_ofx.py
+++ b/tests/test_models_ofx.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for models.ofx """
+"""Unit tests for models.ofx"""
 # stdlib imports
 import unittest
 from xml.etree.ElementTree import Element

--- a/tests/test_models_profile.py
+++ b/tests/test_models_profile.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for models.profile """
+"""Unit tests for models.profile"""
 # stdlib imports
 import unittest
 from xml.etree.ElementTree import Element, SubElement

--- a/tests/test_models_securities.py
+++ b/tests/test_models_securities.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for ofxtools.models.seclist """
+"""Unit tests for ofxtools.models.seclist"""
 
 # stdlib imports
 import unittest

--- a/tests/test_models_signon.py
+++ b/tests/test_models_signon.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for models.signon """
+"""Unit tests for models.signon"""
 # stdlib imports
 import unittest
 from xml.etree.ElementTree import Element, SubElement

--- a/tests/test_models_signup.py
+++ b/tests/test_models_signup.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for ofxtools.models.signup """
+"""Unit tests for ofxtools.models.signup"""
 # stdlib imports
 import unittest
 from xml.etree.ElementTree import Element, SubElement

--- a/tests/test_ofxget.py
+++ b/tests/test_ofxget.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for ofxtools.ofxget """
+"""Unit tests for ofxtools.ofxget"""
 
 # stdlib imports
 import unittest

--- a/tests/test_ofxhome.py
+++ b/tests/test_ofxhome.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for ofxtools.ofxhome """
+"""Unit tests for ofxtools.ofxhome"""
 
 # stdlib imports
 import unittest

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for ofxtools.Parser """
+"""Unit tests for ofxtools.Parser"""
 
 # stdlib imports
 import unittest

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for ofxtools.Types """
+"""Unit tests for ofxtools.Types"""
 # stdlib imports
 import unittest
 import decimal

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -410,7 +410,7 @@ class DecimalTestCase(unittest.TestCase, Base):
         self.assertEqual(t.convert(t.unconvert(value)), value)
 
 
-class TestingTimezone(datetime.tzinfo):
+class _TestingTimezone(datetime.tzinfo):
     """Timezone info class for testing purposes"""
 
     def __init__(self, name: str, offset: datetime.timedelta):
@@ -427,9 +427,9 @@ class TestingTimezone(datetime.tzinfo):
         return self.name
 
 
-CST = TestingTimezone("CST", datetime.timedelta(hours=-6))
-IST = TestingTimezone("IST", datetime.timedelta(hours=5, minutes=30))
-NST = TestingTimezone("NST", datetime.timedelta(hours=-3.5))
+CST = _TestingTimezone("CST", datetime.timedelta(hours=-6))
+IST = _TestingTimezone("IST", datetime.timedelta(hours=5, minutes=30))
+NST = _TestingTimezone("NST", datetime.timedelta(hours=-3.5))
 
 
 class DateTimeTestCase(unittest.TestCase, Base):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-""" Unit tests for ofxtools.utils """
+"""Unit tests for ofxtools.utils"""
 # stdlib imports
 import unittest
 import os


### PR DESCRIPTION
To enable support for newer Python versions, Python 3.12, 3.13, and 3.14 were added to the CI commit configuration and `setup.py`.

A pytest warning of TestingTimezone was resolved by renaming it to __TestingTimezone, preventing pytest from incorrectly treating it as a test instead of a helper class.

To ensure the test were successfull, I formatted the repository using black. Additionally, `import urllib.request` was added to file `ofxhome.py`, to avoid mypy checks errors when running Python 3.11 or above.

After these changes, all tests passed successfully. Code coverage stayed the same as before. The builds were completed successfully across all supported Python versions, from 3.8 through 3.14.

Closes #201 